### PR TITLE
Resolve inconsistencies with TSLPatcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ ignore
 build/*
 *.pyc
 pykotor/gl
+.vscode/launch.json
+debug.log
+pykotorcli.spec

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ venv
 dist
 PyKotor.egg-info
 ignore
+build/*
+*.pyc
+pykotor/gl

--- a/pykotor/tslpatcher/config.py
+++ b/pykotor/tslpatcher/config.py
@@ -228,6 +228,12 @@ class ModInstaller:
                 erf.set(resname, restype, data)
                 write_erf(erf, destination)
         else:
-            filepath = f"{destination}"
+            # todo: fix later
+            base_name, extension = os.path.splitext(destination)
+            filepath = None
+            if extension:
+                filepath = f"{destination}"
+            else:
+                filepath = os.path.join(f"{destination}", filename)
             if not os.path.exists(filepath) or replace:
                 BinaryWriter.dump(filepath, data)

--- a/pykotor/tslpatcher/logger.py
+++ b/pykotor/tslpatcher/logger.py
@@ -13,12 +13,15 @@ class PatchLogger:
         self.patches_completed += 1
 
     def add_note(self, message: str) -> None:
+        print("Note: " + message)
         self.notes.append(PatchLog(message))
 
     def add_warning(self, message: str) -> None:
+        print("Warning: " + message)
         self.warnings.append(PatchLog(message))
 
     def add_error(self, message: str) -> None:
+        print("Error: " + message)
         self.errors.append(PatchLog(message))
 
 

--- a/pykotor/tslpatcher/reader.py
+++ b/pykotor/tslpatcher/reader.py
@@ -309,13 +309,11 @@ class ConfigReader:
         files = dict(self.ini["CompileList"].items())
 
         for identifier, file in files.items():
-            modifications_ini = dict(self.ini[file].items())
             replace = identifier.startswith("Replace")
-
             modifications = ModificationsNSS(file, replace)
             self.config.patches_nss.append(modifications)
 
-            for name, value in modifications_ini.items():
+            for name, value in files.items():
                 if name.lower() == "!destination":
                     modifications.destination = value
 
@@ -420,10 +418,10 @@ class ConfigReader:
                 value.set(language, gender, text)
             value = FieldValueConstant(value)
         elif field_type.return_type() == Vector3:
-            components = [float(axis) for axis in raw_value.split("|")]
+            components = [float(axis.replace(",", ".")) for axis in raw_value.split("|")]
             value = FieldValueConstant(Vector3(*components))
         elif field_type.return_type() == Vector4:
-            components = [float(axis) for axis in raw_value.split("|")]
+            components = [float(axis.replace(",", ".")) for axis in raw_value.split("|")]
             value = FieldValueConstant(Vector4(*components))
         elif field_type.return_type() == GFFList:
             value = FieldValueConstant(GFFList())
@@ -587,7 +585,7 @@ class NamespaceReader:
     @classmethod
     def from_filepath(cls, path: str) -> List[PatcherNamespace]:
         ini_text = BinaryReader.load_file(path).decode()
-        ini = ConfigParser(interpolation=None)
+        ini = ConfigParser()
         ini.optionxform = str
         ini.read_string(ini_text)
         return NamespaceReader(ini).load()
@@ -605,7 +603,7 @@ class NamespaceReader:
             namespace.info_filename = self.ini[namespace_id]["InfoName"]
             namespace.data_folderpath = self.ini[namespace_id].get("DataPath")
             namespace.name = self.ini[namespace_id].get("Name")
-            namespace.description = self.ini[namespace_id]["Description"]
+            namespace.description = self.ini[namespace_id].get("Description")
             namespaces.append(namespace)
 
         return namespaces

--- a/pykotorcli.py
+++ b/pykotorcli.py
@@ -1,0 +1,92 @@
+import os
+import sys
+
+from enum import Enum
+from pykotor.tslpatcher.config import ModInstaller
+from pykotor.tslpatcher.reader import NamespaceReader
+
+class ExitCode(Enum):
+    Success = 0
+    NumberOfArgs = 1
+    NamespacesIniNotFound = 2
+    NamespaceIndexOutOfRange = 3
+    ChangesIniNotFound = 4
+
+if len(sys.argv) < 3 or len(sys.argv) > 4:
+    print("Syntax: pykotorcli.exe [\"\\path\\to\\game\\dir\"] [\"\\path\\to\\tslpatchdata\"] {\"namespace_option_index\"}")
+    sys.exit(ExitCode.NumberOfArgs)
+
+game_path = sys.argv[1]
+tslpatchdata_path = sys.argv[2]
+namespace_index = None
+changes_ini_path = None
+
+if len(sys.argv) == 3:
+    changes_ini_path = os.path.join(tslpatchdata_path, "tslpatchdata", "changes.ini")
+elif len(sys.argv) == 4:
+    try:
+        namespace_index = int(sys.argv[3])
+    except ValueError:
+        print("Invalid namespace_option_index. It should be an integer.")
+        sys.exit(ExitCode.NamespaceIndexOutOfRange)
+
+    namespaces_ini_path = os.path.join(tslpatchdata_path, "tslpatchdata", "namespaces.ini")
+    print("Using namespaces.ini path: " + namespaces_ini_path)
+    if not os.path.exists(namespaces_ini_path):
+        print("The 'namespaces.ini' file was not found in the specified tslpatchdata path.")
+        sys.exit(ExitCode.NamespacesIniNotFound)
+
+    loaded_namespaces = NamespaceReader.from_filepath(namespaces_ini_path)
+    if namespace_index is None or namespace_index >= len(loaded_namespaces):
+        print("Namespace index is out of range.")
+        sys.exit(ExitCode.NamespaceIndexOutOfRange)
+    
+    if loaded_namespaces[namespace_index].data_folderpath:
+        changes_ini_path = os.path.join(
+            tslpatchdata_path,
+            "tslpatchdata",
+            loaded_namespaces[namespace_index].data_folderpath,
+            loaded_namespaces[namespace_index].ini_filename
+        )
+    else:
+        changes_ini_path = os.path.join(
+            tslpatchdata_path,
+            "tslpatchdata",
+            loaded_namespaces[namespace_index].ini_filename
+        )
+print("Using changes.ini path: " + changes_ini_path)
+if not os.path.exists(changes_ini_path):
+    print("The 'changes.ini' file could not be found.")
+    sys.exit(ExitCode.ChangesIniNotFound)
+
+mod_path = os.path.dirname(os.path.abspath(changes_ini_path))
+ini_name = os.path.basename(changes_ini_path)
+
+installer = ModInstaller(mod_path, game_path, ini_name)
+installer.install()
+
+# Print the log messages to the console
+for note in installer.log.notes:
+    print(f"[Note] {note.message}")
+
+for warning in installer.log.warnings:
+    print(f"[Warning] {warning.message}")
+
+for error in installer.log.errors:
+    print(f"[Error] {error.message}")
+        
+print ("Create log file...")
+
+log_file_path = os.path.join(tslpatchdata_path, "installlog.txt")
+with open(log_file_path, "w") as log_file:
+    for note in installer.log.notes:
+        log_file.write(f"[Note] {note.message}\n")
+
+    for warning in installer.log.warnings:
+        log_file.write(f"[Warning] {warning.message}\n")
+
+    for error in installer.log.errors:
+        log_file.write(f"[Error] {error.message}\n")
+        
+print ("Logging finished")
+sys.exit()

--- a/pykotorcli.py
+++ b/pykotorcli.py
@@ -79,28 +79,18 @@ ini_name = os.path.basename(changes_ini_path)
 installer = ModInstaller(mod_path, game_path, ini_name)
 installer.install()
 
-# Print the log messages to the console
-for note in installer.log.notes:
-    print(f"[Note] {note.message}")
-
-for warning in installer.log.warnings:
-    print(f"[Warning] {warning.message}")
-
-for error in installer.log.errors:
-    print(f"[Error] {error.message}")
-        
-print ("Create log file...")
+print ("Writing log file 'installlog.txt'...")
 
 log_file_path = os.path.join(tslpatchdata_path, "installlog.txt")
 with open(log_file_path, "w") as log_file:
     for note in installer.log.notes:
-        log_file.write(f"[Note] {note.message}\n")
+        log_file.write(f"{note.message}\n")
 
     for warning in installer.log.warnings:
-        log_file.write(f"[Warning] {warning.message}\n")
+        log_file.write(f"Warning: {warning.message}\n")
 
     for error in installer.log.errors:
-        log_file.write(f"[Error] {error.message}\n")
+        log_file.write(f"Error: {error.message}\n")
         
 print ("Logging finished")
 sys.exit()

--- a/pykotorcli.py
+++ b/pykotorcli.py
@@ -5,6 +5,20 @@ from enum import Enum
 from pykotor.tslpatcher.config import ModInstaller
 from pykotor.tslpatcher.reader import NamespaceReader
 
+# Override the print function to flush immediately
+def custom_print(*args, **kwargs):
+    builtins_print(*args, **kwargs)
+    sys.stdout.flush()
+
+# Replace the built-in print function
+builtins_print = print
+print = custom_print
+
+# Replace the print function in the imported modules
+sys.modules['pykotor.tslpatcher.reader'].print = custom_print
+sys.modules['pykotor.tslpatcher.config'].print = custom_print
+
+
 class ExitCode(Enum):
     Success = 0
     NumberOfArgs = 1


### PR DESCRIPTION
This can be messy, but since it's unrealistic to modify all released tslpatcher mods to support both syntax's it seems logical to update PyKotor to handle what TSLPatcher has been supporting for decades.

EDIT: It seems that PyKotor does not validate anything during an install. For example, I tried installing a mod that I purposefully broke using GFFList. This caused PyKotor to show the operations it was performing, but there was no validation or analysis of anything it was doing. Loading the game up caused an infinite loading screen as it couldn't load the `.mod`. So there may be unknown hidden issues other than the below scenarios. It's also possible that this scenario was caused by my changes below.

I've tested hundreds of mods, 90% of them install correctly, or at least without pykotor errors or problems during a playthrough so far.
The following problems were observed in the other 10%:
- [FIXED] `configparser.py`'s RawConfigParser's `_read` needs to ignore when section header is missing. We override in the `reader.py` here.
- [FIXED] Use `.get` in `config.py` to read the ini file, as most of the fields aren't required and shouldn't throw errors if not defined.
- [FIXED] TSLPatcher ini keys are case insensitive while PyKotor is expecting case-sensitive keys.
- [FIXED] #5 float fields now handle comma separators in addition to dot separators
- [ FIXED, but could be refactored ] #6 
- [ FIXED, but could be refactored ] #8 
- #9
- #10 

PyKotor is an amazing project, thank you for creating this library!