### PR TITLE
Fix loading of ERF types from header.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pykotor/gl
 .vscode/launch.json
 debug.log
 pykotorcli.spec
+pykotorcli.build/*

--- a/pykotor/resource/formats/erf/erf_auto.py
+++ b/pykotor/resource/formats/erf/erf_auto.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 from pykotor.common.stream import BinaryReader
-from pykotor.resource.formats.erf import ERF, ERFBinaryReader, ERFBinaryWriter, ERFType
+from pykotor.resource.formats.erf import ERF, ERFBinaryReader, ERFBinaryWriter
 from pykotor.resource.type import ResourceType
 
 
@@ -50,12 +50,6 @@ def write_erf(
         ValueError: If the specified format was unsupported.
     """
     if file_format == ResourceType.ERF or file_format == ResourceType.MOD:
-        # Correct the ERF's ERFType to match the file extension
-        if file_format == ResourceType.ERF:
-            erf.erf_type = ERFType.ERF
-        elif file_format == ResourceType.MOD:
-            erf.erf_type = ERFType.MOD
-
         ERFBinaryWriter(erf, target).write()
     else:
         raise ValueError("Unsupported format specified; use ERF or MOD.")

--- a/pykotor/resource/formats/erf/io_erf.py
+++ b/pykotor/resource/formats/erf/io_erf.py
@@ -21,16 +21,19 @@ class ERFBinaryReader(ResourceReader):
             self,
             auto_close: bool = True
     ) -> ERF:
-        self._erf = ERF()
 
         file_type = self._reader.read_string(4)
         file_version = self._reader.read_string(4)
 
-        if not any(x for x in ERFType if x.value == file_type):
-            raise ValueError("Not a valid ERF file.")
+        erf_type_map = {x.value: x for x in ERFType}
+
+        if file_type not in erf_type_map:
+            raise ValueError(f"Not a valid ERF file: {file_type}")
+        
+        self._erf = ERF(erf_type_map.get(file_type))
 
         if file_version != "V1.0":
-            raise ValueError("The ERF version that was loaded is unsupported.")
+            raise ValueError(f"ERF version '{file_version}' is unsupported.")
 
         self._reader.skip(8)
         entry_count = self._reader.read_uint32()

--- a/pykotor/resource/formats/erf/io_erf.py
+++ b/pykotor/resource/formats/erf/io_erf.py
@@ -28,7 +28,7 @@ class ERFBinaryReader(ResourceReader):
         erf_type_map = {x.value: x for x in ERFType}
 
         if file_type not in erf_type_map:
-            raise ValueError(f"Not a valid ERF file: {file_type}")
+            raise ValueError(f"Not a valid ERF file: '{file_type}'")
         
         self._erf = ERF(erf_type_map.get(file_type))
 

--- a/pykotor/tslpatcher/config.py
+++ b/pykotor/tslpatcher/config.py
@@ -5,6 +5,7 @@ from enum import IntEnum
 from typing import List, Dict, Optional
 
 from pykotor.extract.capsule import Capsule
+from pykotor.resource.formats.erf.erf_data import ERFType
 
 from pykotor.resource.formats.gff.gff_auto import bytes_gff
 
@@ -224,7 +225,7 @@ class ModInstaller:
                 rim.set(resname, restype, data)
                 write_rim(rim, destination)
         elif file_extension.lower() == ".mod" or file_extension.lower() == ".rim":
-            erf = read_erf(BinaryReader.load_file(destination)) if os.path.exists(destination) else ERF(file_extension)
+            erf = read_erf(BinaryReader.load_file(destination)) if os.path.exists(destination) else ERF(ERFType.from_extension(file_extension))
             if not erf.get(resname, restype) or replace:
                 erf.set(resname, restype, data)
                 write_erf(erf, destination)

--- a/pykotor/tslpatcher/config.py
+++ b/pykotor/tslpatcher/config.py
@@ -217,13 +217,14 @@ class ModInstaller:
 
     def write(self, destination: str, filename: str, data: bytes, replace: bool = False) -> None:
         resname, restype = ResourceIdentifier.from_path(filename)
-        if destination.endswith(".rim"):
+        file_extension = os.path.splitext(destination)[1]
+        if file_extension.lower() == ".rim":
             rim = read_rim(BinaryReader.load_file(destination)) if os.path.exists(destination) else RIM()
             if not rim.get(resname, restype) or replace:
                 rim.set(resname, restype, data)
                 write_rim(rim, destination)
-        elif destination.endswith(".mod") or destination.endswith(".erf"):
-            erf = read_erf(BinaryReader.load_file(destination)) if os.path.exists(destination) else ERF()
+        elif file_extension.lower() == ".mod" or file_extension.lower() == ".rim":
+            erf = read_erf(BinaryReader.load_file(destination)) if os.path.exists(destination) else ERF(file_extension)
             if not erf.get(resname, restype) or replace:
                 erf.set(resname, restype, data)
                 write_erf(erf, destination)


### PR DESCRIPTION
In the ERFBinaryReader, the ERF type string from the file header is never used to create the ERF object. This PR fixes that problem, and partially fixes #11 

EDIT: Have just tested a full modbuild install and quickly played through parts of the game, this PR seems to fix #11 completely.