### PR TITLE
add TLKReplaceList requested by DarthParametric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ pykotor/gl
 .vscode/launch.json
 debug.log
 pykotorcli.spec
+pykotorcli.build/*
+.history/*
+*.heapsnapshot
+*.cpuprofile

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["chardet"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-  "cSpell.words": ["chardet"]
+  "cSpell.words": ["Battlecry", "chardet", "installlog", "strref"],
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.autopep8"
+  },
+  "python.formatting.provider": "none"
 }

--- a/pykotor/resource/formats/tlk/tlk_data.py
+++ b/pykotor/resource/formats/tlk/tlk_data.py
@@ -79,6 +79,20 @@ class TLK:
         entry = TLKEntry(text, ResRef(sound_resref))
         self.entries.append(entry)
         return len(self.entries) - 1
+    
+    def replace(self, stringref: int, text: str, sound_resref: str = "") -> None:
+        """
+        Replaces an entry at the specified stringref with the provided text and sound resref.
+
+        Args:
+            stringref: The stringref of the entry to be replaced.
+            text: The new text for the entry.
+            sound_resref: The new sound resref for the entry.
+        """
+        if 0 <= stringref < len(self.entries):
+            self.entries[stringref] = TLKEntry(text, ResRef(sound_resref))
+        else:
+            raise IndexError("Stringref does not exist.")
 
     def resize(
             self,

--- a/pykotor/tslpatcher/config.py
+++ b/pykotor/tslpatcher/config.py
@@ -107,8 +107,22 @@ class ModInstaller:
         """
 
         if self._config is None:
-            ini_text = BinaryReader.load_file(self.mod_path + "/" + self.ini_file).decode()
-            append_tlk = read_tlk(self.mod_path + "/append.tlk") if os.path.exists(self.mod_path + "/append.tlk") else TLK()
+            ini_file_bytes = BinaryReader.load_file(f"{self.mod_path}/{self.ini_file}")
+            ini_text = None
+            try:
+                ini_text = ini_file_bytes.decode()
+            except UnicodeDecodeError:
+                try:
+                    # If UTF-8 failed, try 'cp1252' (similar to ANSI)
+                    ini_text = ini_file_bytes.decode('cp1252')
+                except UnicodeDecodeError as e:
+                    # Raise an exception if all decodings failed
+                    raise Exception('Could not decode file') from e
+            append_tlk = (
+                read_tlk(f"{self.mod_path}/append.tlk")
+                if os.path.exists(f"{self.mod_path}/append.tlk")
+                else TLK()
+            )
             self._config = PatcherConfig()
             self._config.load(ini_text, append_tlk, self.mod_path)
 

--- a/pykotor/tslpatcher/config.py
+++ b/pykotor/tslpatcher/config.py
@@ -67,14 +67,14 @@ class PatcherConfig:
         self.patches_nss: List[ModificationsNSS] = []
         self.patches_tlk: ModificationsTLK = ModificationsTLK()
 
-    def load(self, ini_text: str, append: TLK, mod_path: str) -> None:
+    def load(self, ini_text: str, mod_path: str) -> None:
         from pykotor.tslpatcher.reader import ConfigReader
 
         ini = ConfigParser()
         ini.optionxform = str
         ini.read_string(ini_text)
 
-        ConfigReader(ini, append, mod_path).load(self)
+        ConfigReader(ini, mod_path).load(self)
 
     def patch_count(self) -> int:
         return len(self.patches_2da) + len(self.patches_gff) + len(self.patches_ssf) + 1 + len(self.install_list) + len(self.patches_nss)
@@ -118,13 +118,8 @@ class ModInstaller:
                 except UnicodeDecodeError as e:
                     # Raise an exception if all decodings failed
                     raise Exception('Could not decode file') from e
-            append_tlk = (
-                read_tlk(f"{self.mod_path}/append.tlk")
-                if os.path.exists(f"{self.mod_path}/append.tlk")
-                else TLK()
-            )
             self._config = PatcherConfig()
-            self._config.load(ini_text, append_tlk, self.mod_path)
+            self._config.load(ini_text, self.mod_path)
 
         return self._config
 

--- a/pykotor/tslpatcher/config.py
+++ b/pykotor/tslpatcher/config.py
@@ -66,16 +66,15 @@ class PatcherConfig:
         self.patches_ssf: List[ModificationsSSF] = []
         self.patches_nss: List[ModificationsNSS] = []
         self.patches_tlk: ModificationsTLK = ModificationsTLK()
-        self.patches_tlk_replace: ModificationsTLK = ModificationsTLK()
 
-    def load(self, ini_text: str, append: TLK, replace: TLK) -> None:
+    def load(self, ini_text: str, append: TLK, mod_path: str) -> None:
         from pykotor.tslpatcher.reader import ConfigReader
 
         ini = ConfigParser()
         ini.optionxform = str
         ini.read_string(ini_text)
 
-        ConfigReader(ini, append, replace).load(self)
+        ConfigReader(ini, append, mod_path).load(self)
 
     def patch_count(self) -> int:
         return len(self.patches_2da) + len(self.patches_gff) + len(self.patches_ssf) + 1 + len(self.install_list) + len(self.patches_nss)
@@ -110,9 +109,8 @@ class ModInstaller:
         if self._config is None:
             ini_text = BinaryReader.load_file(self.mod_path + "/" + self.ini_file).decode()
             append_tlk = read_tlk(self.mod_path + "/append.tlk") if os.path.exists(self.mod_path + "/append.tlk") else TLK()
-            replace_tlk = read_tlk(self.mod_path + "/replace.tlk") if os.path.exists(self.mod_path + "/replace.tlk") else TLK()
             self._config = PatcherConfig()
-            self._config.load(ini_text, append_tlk, replace_tlk)
+            self._config.load(ini_text, append_tlk, self.mod_path)
 
         return self._config
 
@@ -128,7 +126,6 @@ class ModInstaller:
         # Apply changes to dialog.tlk
         dialog_tlk = read_tlk(installation.path() + "dialog.tlk")
         config.patches_tlk.apply(dialog_tlk, memory)
-        config.patches_tlk.apply_replacements(dialog_tlk, memory)
         write_tlk(dialog_tlk, self.output_path + "/dialog.tlk")
         self.log.complete_patch()
 

--- a/pykotor/tslpatcher/mods/tlk.py
+++ b/pykotor/tslpatcher/mods/tlk.py
@@ -32,4 +32,3 @@ class ModifyTLK:
 
     def apply_replacements(self, dialog: TLK, memory: PatcherMemory) -> None:
         dialog.replace(self.token_id, self.text, self.sound.get())
-        memory.memory_str[self.token_id] = self.token_id

--- a/pykotor/tslpatcher/mods/tlk.py
+++ b/pykotor/tslpatcher/mods/tlk.py
@@ -14,6 +14,10 @@ class ModificationsTLK:
     def apply(self, dialog: TLK, memory: PatcherMemory) -> None:
         for modifier in self.modifiers:
             modifier.apply(dialog, memory)
+            
+    def apply_replacements(self, dialog: TLK, memory: PatcherMemory) -> None:
+        for modifier in self.modifiers:
+            modifier.apply_replacements(dialog, memory)
 
 
 class ModifyTLK:
@@ -25,3 +29,7 @@ class ModifyTLK:
     def apply(self, dialog: TLK, memory: PatcherMemory) -> None:
         dialog.add(self.text, self.sound.get())
         memory.memory_str[self.token_id] = len(dialog.entries) - 1
+
+    def apply_replacements(self, dialog: TLK, memory: PatcherMemory) -> None:
+        dialog.replace(self.token_id, self.text, self.sound.get())
+        memory.memory_str[self.token_id] = self.token_id

--- a/pykotor/tslpatcher/mods/tlk.py
+++ b/pykotor/tslpatcher/mods/tlk.py
@@ -13,22 +13,21 @@ class ModificationsTLK:
 
     def apply(self, dialog: TLK, memory: PatcherMemory) -> None:
         for modifier in self.modifiers:
-            modifier.apply(dialog, memory)
-            
-    def apply_replacements(self, dialog: TLK, memory: PatcherMemory) -> None:
-        for modifier in self.modifiers:
-            modifier.apply_replacements(dialog, memory)
-
+            if modifier.is_replacement:
+                modifier.replace(dialog)
+            else:
+                modifier.insert(dialog, memory)
 
 class ModifyTLK:
-    def __init__(self, token_id, text: str, sound: ResRef):
+    def __init__(self, token_id: int, text: str, sound: ResRef, is_replacement: bool):
         self.token_id: int = token_id
         self.text: str = text
         self.sound: ResRef = sound
+        self.is_replacement: bool = is_replacement
 
-    def apply(self, dialog: TLK, memory: PatcherMemory) -> None:
+    def insert(self, dialog: TLK, memory: PatcherMemory) -> None:
         dialog.add(self.text, self.sound.get())
         memory.memory_str[self.token_id] = len(dialog.entries) - 1
 
-    def apply_replacements(self, dialog: TLK, memory: PatcherMemory) -> None:
+    def replace(self, dialog: TLK) -> None:
         dialog.replace(self.token_id, self.text, self.sound.get())

--- a/pykotor/tslpatcher/reader.py
+++ b/pykotor/tslpatcher/reader.py
@@ -146,7 +146,17 @@ class ConfigReader:
 
     @classmethod
     def from_filepath(cls, path: str, append_path: Optional[str]) -> PatcherConfig:
-        ini_text = BinaryReader.load_file(path).decode()
+        ini_file_bytes = BinaryReader.load_file(path)
+        ini_text = None
+        try:
+            ini_text = ini_file_bytes.decode()
+        except UnicodeDecodeError:
+            try:
+                # If UTF-8 failed, try 'cp1252' (similar to ANSI)
+                ini_text = ini_file_bytes.decode('cp1252')
+            except UnicodeDecodeError:
+                # Raise an exception if all decodings failed
+                raise Exception('Could not decode file')
         ini = ConfigParser()
         ini.optionxform = str
         ini.read_string(ini_text)
@@ -197,7 +207,7 @@ class ConfigReader:
 
         for name, value in stringrefs.items():
             if "\\" in name:  # Handle in-line updates
-                
+
                 token_id = int(name.split("\\")[0])
                 property_name = name.split("\\")[1]
                 entry = self.dialog_tlk_edits.get(token_id)
@@ -208,11 +218,11 @@ class ConfigReader:
                     entry.voiceover = value
                 else:
                     raise KeyError(f"Invalid TLKList syntax for key '{name}' value '{value}'")
-                    
+
                 self.config.patches_tlk.modifiers.append(modifier)
 
             elif name.lower().startswith("file"):  # Handle multiple files
-                
+
                 tlk_file_path = os.path.join(self.mod_path, value)
                 tlk_data_entries = None
                 if os.path.exists(tlk_file_path):
@@ -228,7 +238,7 @@ class ConfigReader:
                         self.config.patches_tlk.modifiers.append(modifier)
                 else:
                     raise KeyError(f"'{value}' Ini header referenced in TLKList not found.")
-                
+
             elif name.lower().startswith("strref"): # Handle legacy syntax
                 token_id = int(name[6:])
                 append_index = int(value)
@@ -623,7 +633,17 @@ class NamespaceReader:
 
     @classmethod
     def from_filepath(cls, path: str) -> List[PatcherNamespace]:
-        ini_text = BinaryReader.load_file(path).decode()
+        ini_file_bytes = BinaryReader.load_file(path)
+        ini_text = None
+        try:
+            ini_text = ini_file_bytes.decode()
+        except UnicodeDecodeError:
+            try:
+                # If UTF-8 failed, try 'cp1252' (similar to ANSI)
+                ini_text = ini_file_bytes.decode('cp1252')
+            except UnicodeDecodeError:
+                # Raise an exception if all decodings failed
+                raise Exception('Could not decode file')
         ini = ConfigParser()
         ini.optionxform = str
         ini.read_string(ini_text)

--- a/pykotor/tslpatcher/reader.py
+++ b/pykotor/tslpatcher/reader.py
@@ -224,7 +224,7 @@ class ConfigReader:
                     for token_id, change_index in custom_tlk_entries.items():
                         entry = tlk_data_entries.get(int(token_id))
 
-                        modifier = ModifyTLK(change_index, entry.text, entry.voiceover, is_replacement = True)
+                        modifier = ModifyTLK(int(change_index), entry.text, entry.voiceover, is_replacement = True)
                         self.config.patches_tlk.modifiers.append(modifier)
                 else:
                     raise KeyError(f"'{value}' Ini header referenced in TLKList not found.")

--- a/pykotor/tslpatcher/reader.py
+++ b/pykotor/tslpatcher/reader.py
@@ -221,7 +221,7 @@ class ConfigReader:
                     raise FileNotFoundError(f"Cannot find TLK file: '{value}' at key '{name}' in TLKList")
                 if value in self.ini:
                     custom_tlk_entries = dict(self.ini[value].items()) # get the entries from the custom header
-                    for token_id, change_index in custom_tlk_entries.items():
+                    for change_index, token_id in custom_tlk_entries.items():
                         entry = tlk_data_entries.get(int(token_id))
 
                         modifier = ModifyTLK(int(change_index), entry.text, entry.voiceover, is_replacement = True)

--- a/pykotor/tslpatcher/reader.py
+++ b/pykotor/tslpatcher/reader.py
@@ -137,9 +137,10 @@ class ConfigParser(RawConfigParser):
             raise e
 
 class ConfigReader:
-    def __init__(self, ini: ConfigParser, append: TLK) -> None:
+    def __init__(self, ini: ConfigParser, append: TLK, replace: TLK) -> None:
         self.ini = ini
         self.append: TLK = append
+        self.replace: TLK = replace
 
         self.config: Optional[PatcherConfig] = None
 
@@ -161,6 +162,7 @@ class ConfigReader:
         self.load_settings()
         self.load_filelist()
         self.load_stringref()
+        self.load_stringref_replacement()
         self.load_2da()
         self.load_ssf()
         self.load_gff()
@@ -200,6 +202,22 @@ class ConfigReader:
 
             modifier = ModifyTLK(token_id, entry.text, entry.voiceover)
             self.config.patches_tlk.modifiers.append(modifier)
+            
+    def load_stringref_replacement(self) -> None:
+        if "TLKReplaceList" not in self.ini:
+            return
+
+        stringrefs = dict(self.ini["TLKReplaceList"].items())
+
+        index = 0
+        
+        for name, value in stringrefs.items():
+            replace_index = int(value)
+            entry = self.replace.get(index)
+
+            modifier = ModifyTLK(replace_index, entry.text, entry.voiceover)
+            self.config.patches_tlk.modifiers.append(modifier)
+            index += 1
 
     def load_2da(self) -> None:
         if "2DAList" not in self.ini:

--- a/pykotor/tslpatcher/reader.py
+++ b/pykotor/tslpatcher/reader.py
@@ -235,8 +235,8 @@ class ConfigReader:
                     raise KeyError(f"INI header for '{value}' referenced in TLKList key '{key}' not found.")
                 custom_tlk_entries = dict(self.ini[value].items()) # get the entries from the custom header e.g. [update1.tlk]
                 for change_index, token_id_str in custom_tlk_entries.items(): # replace the specified indices e.g. 1977=421
-                    entry = tlk_data_entries.get(int(token_id_str))
-                    modifier = ModifyTLK(int(change_index), entry.text, entry.voiceover, is_replacement = True)
+                    entry = tlk_data_entries.get(int(change_index))
+                    modifier = ModifyTLK(int(token_id_str), entry.text, entry.voiceover, is_replacement = True)
                     self.config.patches_tlk.modifiers.append(modifier)
             elif "\\" in key or "/" in key:  # Handle in-line updates e.g. 2003\Text="Peace is a lie; there is only passion."
                 delimiter = "\\" if "\\" in key else "/"

--- a/pykotorcli.py
+++ b/pykotorcli.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from enum import Enum
+from enum import Enum, IntEnum
 from pykotor.tslpatcher.config import ModInstaller
 from pykotor.tslpatcher.reader import NamespaceReader
 
@@ -19,7 +19,7 @@ sys.modules['pykotor.tslpatcher.reader'].print = custom_print
 sys.modules['pykotor.tslpatcher.config'].print = custom_print
 
 
-class ExitCode(Enum):
+class ExitCode(IntEnum):
     Success = 0
     NumberOfArgs = 1
     NamespacesIniNotFound = 2
@@ -51,10 +51,10 @@ elif len(sys.argv) == 4:
         sys.exit(ExitCode.NamespacesIniNotFound)
 
     loaded_namespaces = NamespaceReader.from_filepath(namespaces_ini_path)
-    if namespace_index is None or namespace_index >= len(loaded_namespaces):
+    if namespace_index >= len(loaded_namespaces):
         print("Namespace index is out of range.")
         sys.exit(ExitCode.NamespaceIndexOutOfRange)
-    
+
     if loaded_namespaces[namespace_index].data_folderpath:
         changes_ini_path = os.path.join(
             tslpatchdata_path,
@@ -91,6 +91,6 @@ with open(log_file_path, "w") as log_file:
 
     for error in installer.log.errors:
         log_file.write(f"Error: {error.message}\n")
-        
+
 print ("Logging finished")
 sys.exit()


### PR DESCRIPTION
TSLPatcher has the ability to modify the `dialog.tlk` file and add new dialog to it. However it doesn't have the ability to replace individual lines, and the syntax is a bit obnoxious in my opinion.

With DarthParametric's and JC's insights, this is a PR designed to add the means to replace lines in a dialog.tlk. This PR supports two brand new syntaxes:

```
; multiple files
[TLKList]
File0=mytlk.tlk
File1=another.tlk

[mytlk.tlk]
10313=0
10315=1
10314=2

[another.tlk]
305=0
306=1
307=2
```
The above example allows you to direct specific dialog lines from two included tlk files and choose to immediately replace the given indices in the main dialog.tlk. The above example replaces 10313, 10315, 10314 in dialog.tlk with the contents of mytlk.tlk's contents at 0,1, and 2 respectively. You can even have another tlk file if you want as shown in the another.tlk above.

The other new syntax allows you to replace/update existing dialog.tlk entries without the additional tlk file included in tslpatchdata:

```
; in-line updates
[TLKList]
10313\Text="yoooo think the Ender Spire has been ambushed or something?" ; in-line updates
10313\Sound=n_m1aotras99000__
10315\Text="We have been bunk mates this whole time we've been stationed here, how do you not know who I am?"
10315\Sound=n_m1aotras99002_
```

Please note currently that the in-line update syntax above requires that you specify *both* the Sound and the Text. If you specify one but not the other, the change will not be patched to the final dialog.tlk. There will be no exception/error when this happens either. For example:
```
[TLKList]
10315\Text="We have been bunk mates this whole time we've been stationed here, how do you not know who I am?"
```
PyKotor will ignore this, as the Sound resref was not specified. You need to specify both the Text and the Sound even if one is to remain unchanged.