### PR TITLE
Fix GFFEditor not saving in xml format

### DIFF
--- a/Libraries/PyKotor/src/pykotor/resource/formats/gff/gff_data.py
+++ b/Libraries/PyKotor/src/pykotor/resource/formats/gff/gff_data.py
@@ -62,6 +62,20 @@ class GFFContent(Enum):
     def get_valid_types(cls) -> set[str]:
         return {x.name for x in cls}
 
+    @classmethod
+    def from_res(cls, resname: str) -> GFFContent | None:
+        lower_resname = resname.lower()
+        gff_content = None
+        if lower_resname == "savenfo":
+            gff_content = GFFContent.NFO
+        elif lower_resname == "partytable":
+            gff_content = GFFContent.PT
+        elif lower_resname == "globalvars":
+            gff_content = GFFContent.GVT
+        elif lower_resname == "inventory":
+            gff_content = GFFContent.INV
+        return gff_content
+
 
 class GFFFieldType(IntEnum):
     """The different types of fields based off what kind of data it stores."""


### PR DESCRIPTION
Fixes a bug where GFF editor will always save in gff format. This also ensures GFFContent is chosen correctly when the ResourceType extension can't be directly mapped.