### PR TITLE
Toolset - Warn user when registry update fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ Tools/HolocronToolset/src/toolset/kits/*/*
 .secrets
 tests/results/
 Tools/HolocronToolset/src/toolset/profiler_output.pstat
+Tools/HolocronToolset/src/toolset/profiler_output.pstat

--- a/Libraries/PyKotor/src/pykotor/tools/registry.py
+++ b/Libraries/PyKotor/src/pykotor/tools/registry.py
@@ -224,6 +224,10 @@ def set_registry_key_value(full_key_path, value_name, value_data):
         - full_key_path: The full registry key path, including the hive.
         - value_name: The name of the value to set.
         - value_data: The data to set for the value.
+
+    Raises:
+    ------
+        - PermissionError: PyKotor doesn't have permission to change the registry (usually fixed by running as admin).
     """
     try:
         import winreg
@@ -243,6 +247,8 @@ def set_registry_key_value(full_key_path, value_name, value_data):
         # Create the registry path
         try:
             create_registry_path(hive, sub_key)
+        except PermissionError:
+            raise
         except Exception as e:  # pylint: disable=W0718  # noqa: BLE001
             print(format_exception_with_variables(e))
             return
@@ -251,9 +257,8 @@ def set_registry_key_value(full_key_path, value_name, value_data):
             # Set the value
             winreg.SetValueEx(key, value_name, 0, winreg.REG_SZ, value_data)
             print(f"Successfully set {value_name} to {value_data} at {hive}\\{sub_key}")
-    except PermissionError as e:
-        print(f"Error: Permission denied creating regkey {full_key_path}")
-        print(e, "\n", repr(e))
+    except PermissionError:
+        raise
     except Exception as e:  # pylint: disable=W0718  # noqa: BLE001
         print(f"An unexpected error occurred: {e}")
         print(format_exception_with_variables(e))

--- a/Libraries/Utility/src/utility/error_handling.py
+++ b/Libraries/Utility/src/utility/error_handling.py
@@ -300,7 +300,7 @@ def with_variable_trace(
                 elif action == "print":
                     print(full_message)  # noqa: T201
                 if log:
-                    with Path("errorlog.txt").open("a") as outfile:
+                    with Path("errorlog.txt", encoding="utf-8").open("a") as outfile:
                         outfile.write(full_message)
                 if rethrow:
                     # Raise an exception with the detailed message


### PR DESCRIPTION
Warn the user when the registry can't be updated for KOTORTool/KScript's version of nwnnsscomp

Example:

![image](https://github.com/NickHugi/PyKotor/assets/2219836/1f69fc15-09ab-4452-b8e4-e1d2ce5596ff)

note: i know it's saying it doesn't match when the paths are the same, but that was just to test the message box.