### PR TITLE
Fix TPCEditor upside-down images

### DIFF
--- a/Tools/HolocronToolset/src/toolset/gui/editors/tpc.py
+++ b/Tools/HolocronToolset/src/toolset/gui/editors/tpc.py
@@ -85,14 +85,17 @@ class TPCEditor(Editor):
         super().load(filepath, resref, restype, data)
 
         if restype in {ResourceType.TPC, ResourceType.TGA}:
+            print("read_tpc")
             self._tpc = read_tpc(data)
+            width, height, rgba = self._tpc.convert(TPCTextureFormat.RGBA, 0, y_flip=True)
+            self._tpc.set_data(width, height, [rgba], TPCTextureFormat.RGBA)
         else:
+            print("pillow image")
             pillow: Image.Image = Image.open(io.BytesIO(data))
             pillow = pillow.convert("RGBA")
-            #pillow = ImageOps.flip(pillow)
+            pillow = ImageOps.flip(pillow)
             self._tpc = TPC()
             self._tpc.set_single(pillow.width, pillow.height, pillow.tobytes(), TPCTextureFormat.RGBA)
-
         width, height, rgba = self._tpc.convert(TPCTextureFormat.RGB, 0)
 
         # Calculate new dimensions maintaining aspect ratio
@@ -160,8 +163,7 @@ class TPCEditor(Editor):
             data = self.extract_tpc_jpeg_bytes()
         return data, b""
 
-    # TODO Rename this here and in `build`
-    def extract_tpc_jpeg_bytes(self):
+    def extract_tpc_jpeg_bytes(self) -> bytes:
         """Extracts image from TPC texture and returns JPEG bytes.
 
         Args:
@@ -188,8 +190,7 @@ class TPCEditor(Editor):
         image.save(dataIO, "JPEG", quality=80)
         return dataIO.getvalue()
 
-    # TODO Rename this here and in `build`
-    def extract_png_bmp_bytes(self):
+    def extract_png_bmp_bytes(self) -> bytes:
         """Extracts texture data from a TPC texture.
 
         Args:


### PR DESCRIPTION
bit of a hacky fix but at least it works. Presumably the original image was getting flipped twice, which is why the 'textures' tab would not have this problem.