### PR TITLE
Change FileResults displayed items

### DIFF
--- a/Tools/HolocronToolset/src/toolset/gui/dialogs/search.py
+++ b/Tools/HolocronToolset/src/toolset/gui/dialogs/search.py
@@ -182,7 +182,10 @@ class FileResults(QDialog):
         self.installation: HTInstallation = installation
 
         for result in results:
-            item = QListWidgetItem(result.filename())
+            filename = result.filename()
+            filepath = result.filepath()
+            parent_name = filepath.name if filename != filepath.name else f"{filepath.parent.name}"
+            item = QListWidgetItem(f"{parent_name}/{filename}")
             item.setData(QtCore.Qt.UserRole, result)
             item.setToolTip(str(result.filepath()))
             self.ui.resultList.addItem(item)
@@ -195,10 +198,6 @@ class FileResults(QDialog):
         Args:
         ----
             self: The object instance.
-
-        Returns:
-        -------
-            None: Does not return anything.
 
         Processes the current selection:
             - Gets the current item from the result list


### PR DESCRIPTION
The FileResults show the filename only. Hovering over does show the filepath in a tooltip but that's not intuitive at first, especially when the results contain duplicate filenames. This PR will now display files as the following:

![image](https://github.com/NickHugi/PyKotor/assets/2219836/d5dc0791-2a1f-45a4-b4b3-29ec149dae59)

Shows the parent, a very simple PR.