### PR TITLE
Attempt to find TXIs when loading TGA's.

### DIFF
--- a/Tools/HolocronToolset/src/toolset/gui/editors/tpc.py
+++ b/Tools/HolocronToolset/src/toolset/gui/editors/tpc.py
@@ -88,7 +88,7 @@ class TPCEditor(Editor):
         # Read image, convert to RGB, and y_flip.
         orig_format = None
         if restype in {ResourceType.TPC, ResourceType.TGA}:
-            self._tpc = read_tpc(data)
+            self._tpc = read_tpc(data, txi_source=filepath)
             orig_format = self._tpc.format()
             width, height, img_bytes = self._tpc.convert(TPCTextureFormat.RGB, 0, y_flip=True)
             self._tpc.set_data(width, height, [img_bytes], TPCTextureFormat.RGB)


### PR DESCRIPTION
`read_tpc` is a fine function but usually we just send the data bytes even though the filepath is sometimes available. This pr modifies `read_tpc` so it'll attempt to look for the txi.
- if source is a filepath to a tpc/tga, attempt to see if the txi is in the same dir with CaseAwarePath
- if txi_source provided, override whatever was in the txi with that data and return it.

Need to determine if TXI files themselves override TPC's TXI's in the game. If so then the logic should be adjusted to match.