### PR TITLE
Fix texture tab case-insensitive filter

### DIFF
--- a/Tools/HolocronToolset/src/toolset/gui/widgets/main_widgets.py
+++ b/Tools/HolocronToolset/src/toolset/gui/widgets/main_widgets.py
@@ -7,7 +7,7 @@ from time import sleep
 from typing import TYPE_CHECKING
 
 from PyQt5 import QtCore
-from PyQt5.QtCore import QPoint, QSortFilterProxyModel, QThread, QTimer
+from PyQt5.QtCore import QPoint, QSortFilterProxyModel, QThread, QTimer, Qt
 from PyQt5.QtGui import QIcon, QImage, QPixmap, QStandardItem, QStandardItemModel, QTransform
 from PyQt5.QtWidgets import QHeaderView, QMenu, QWidget
 
@@ -311,6 +311,7 @@ class TextureList(MainWindowList):
 
         self.texturesModel = QStandardItemModel()
         self.texturesProxyModel = QSortFilterProxyModel()
+        self.texturesProxyModel.setFilterCaseSensitivity(Qt.CaseInsensitive)
         self.texturesProxyModel.setSourceModel(self.texturesModel)
         self.ui.resourceList.setModel(self.texturesProxyModel)
 
@@ -427,7 +428,7 @@ class TextureList(MainWindowList):
             sleep(0.1)
 
     def onFilterStringUpdated(self):
-        self.texturesProxyModel.setFilterFixedString(self.ui.searchEdit.text().casefold())
+        self.texturesProxyModel.setFilterFixedString(self.ui.searchEdit.text())
 
     def onSectionChanged(self):
         self.sectionChanged.emit(self.ui.sectionCombo.currentData(QtCore.Qt.UserRole))


### PR DESCRIPTION
The qProxyViewModel is not being setup as case insensitive yet the code is first casefolding the text to filter. This results in a useless/broken filter that'll only ever show the filtered files if and only if they're lowercase.

This PR fixes that and allows true case-insensitive filtering.