### PR TITLE
Fix DLG camera angle selection

### DIFF
--- a/Tools/HolocronToolset/src/toolset/gui/editors/dlg.py
+++ b/Tools/HolocronToolset/src/toolset/gui/editors/dlg.py
@@ -1075,7 +1075,7 @@ class DLGEditor(Editor):
         node.camera_effect = self.ui.cameraEffectSelect.currentData()
         if node.camera_id >= 0 and self.ui.cameraAngleSelect.currentIndex() == 0:
             self.ui.cameraAngleSelect.setCurrentIndex(6)
-        elif node.camera_id == -1 and self.ui.cameraAngleSelect.currentIndex() == 6:
+        elif node.camera_id == -1 and self.ui.cameraAngleSelect.currentIndex() == 7:
             self.ui.cameraAngleSelect.setCurrentIndex(0)
 
         # Other


### PR DESCRIPTION
There are seven Camera angles and they start from 0, so this check is incorrect:
```python
        elif node.camera_id == -1 and self.ui.cameraAngleSelect.currentIndex() == 6:
            self.ui.cameraAngleSelect.setCurrentIndex(0)
```
should be checking if it's == 7, or better yet check if it's greater than 7. Not sure why this check exists in the first place but w/e

Without this change it's impossible to select 'Static Camera'
![image](https://github.com/NickHugi/PyKotor/assets/2219836/f86069d1-e112-49f1-9352-d9f2516867e1)
