### PR TITLE
Offload `Scene` texture loading to another thread.

### DIFF
--- a/Libraries/PyKotor/src/pykotor/common/module.py
+++ b/Libraries/PyKotor/src/pykotor/common/module.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 
     from pykotor.common.language import LocalizedString
     from pykotor.common.misc import Game, ResRef
-    from pykotor.extract.file import LocationResult, ResourceResult
+    from pykotor.extract.file import FileResource, LocationResult, ResourceResult
     from pykotor.extract.installation import Installation
     from pykotor.resource.formats.erf.erf_data import ERF
     from pykotor.resource.formats.gff.gff_data import GFF
@@ -197,6 +197,7 @@ class ModulePieceResource(Capsule):
     ):
         path_obj = CaseAwarePath.pathify(path)
         self.piece_info: ModulePieceInfo = ModulePieceInfo.from_filename(path_obj.name)
+        self.missing_resources: list[FileResource] = []  # TODO(th3w1zard1)
         super().__init__(path_obj, *args, **kwargs)
 
 

--- a/Libraries/PyKotor/src/pykotor/tools/model.py
+++ b/Libraries/PyKotor/src/pykotor/tools/model.py
@@ -120,7 +120,12 @@ def list_textures(
             if node_id & 32:
                 reader.seek(node_offset + 168)
                 texture = reader.read_string(32, encoding="ascii", errors="ignore").strip()
-                if texture and texture != "NULL" and texture.lower() not in textures:
+                if (
+                    texture
+                    and texture != "NULL"
+                    and texture.lower() not in textures
+                    and texture.lower() != "dirt"  # TODO(th3w1zard1) determine if the game really prevents the literal resname of 'dirt'.
+                ):
                     yield texture.lower()
 
 

--- a/Libraries/PyKotorGL/src/pykotor/gl/models/mdl.py
+++ b/Libraries/PyKotorGL/src/pykotor/gl/models/mdl.py
@@ -335,10 +335,10 @@ class Mesh:
         shader.set_matrix4("model", transform)
 
         glActiveTexture(GL_TEXTURE0)
-        self._scene.texture(override_texture or self.texture).use()
+        self._scene.loadTexture(override_texture or self.texture).use()
 
         glActiveTexture(GL_TEXTURE1)
-        self._scene.texture(self.lightmap, lightmap=True).use()
+        self._scene.loadTexture(self.lightmap, lightmap=True).use()
 
         glBindVertexArray(self._vao)
         glDrawElements(GL_TRIANGLES, self._face_count, GL_UNSIGNED_SHORT, None)


### PR DESCRIPTION
This PR is simple enough: the main bulk of the slowdowns in the Designer is texture io being done in the main thread. Since we can simply show a blank texture this seemed like a slam dunk easy way to speed it up.

Although in reality I ended up rewriting this PR several times. After a week or so of testing, I submit this.