### PR TITLE
Add kw args to Path.stat

### DIFF
--- a/Libraries/Utility/src/utility/system/path.py
+++ b/Libraries/Utility/src/utility/system/path.py
@@ -570,8 +570,8 @@ class Path(PurePath, pathlib.Path):  # type: ignore[misc]
         check: bool | None = None
         try:
             check = self.exists()
-        except (OSError, ValueError, TypeError):
-            RobustRootLogger().debug("This exception has been suppressed and is only relevant for debug purposes.", exc_info=True)
+        except (OSError, ValueError):
+            # RobustRootLogger().debug("This exception has been suppressed and is only relevant for debug purposes.", exc_info=True)
             return None
         else:
             return check

--- a/Libraries/Utility/src/utility/system/path.py
+++ b/Libraries/Utility/src/utility/system/path.py
@@ -512,8 +512,8 @@ class Path(PurePath, pathlib.Path):  # type: ignore[misc]
             self._last_stat_result = super().stat()
         return self._last_stat_result
 
-    def stat(self) -> os.stat_result:
-        self._last_stat_result = super().stat()
+    def stat(self, *args, **kwargs) -> os.stat_result:
+        self._last_stat_result = super().stat(*args, **kwargs)
         return self._last_stat_result
 
     # Safe rglob operation
@@ -570,8 +570,8 @@ class Path(PurePath, pathlib.Path):  # type: ignore[misc]
         check: bool | None = None
         try:
             check = self.exists()
-        except (OSError, ValueError):
-            #RobustRootLogger().debug("This exception has been suppressed and is only relevant for debug purposes.", exc_info=True)
+        except (OSError, ValueError, TypeError):
+            RobustRootLogger().debug("This exception has been suppressed and is only relevant for debug purposes.", exc_info=True)
             return None
         else:
             return check


### PR DESCRIPTION
The `path.Path` class in Libraries/Utility raises a TypeError: "unexpected keyword argument" when used from Python 3.10 or later.

It inherits `pathlib.Path` from Python's stdlib, and overrides the stat() method. It DOESN'T override `pathlib.Path.exists()`, which is implemented as (pseudo-code):

```
def exists(self, args):
  try:
    self.stat(args)  # Calls the overridden stat() if self is a path.Path
  except:
    return False
  return True
```

In Python 3.9's pathlib, exists() and stat() don't take any args, but in 3.10 they added a "follow_symlinks=True" keyword arg. So in Python 3.10 and later, exists() tries to call `self.stat(follow_symlinks=True)`, which raises an exception because the overridden path.Path.stat doesn't expect `follow_symlinks`.

This makes `path.Path.stat` work with any Python version by adding `*args, **kwargs` that get passed through to pathlib.